### PR TITLE
feat: add another Symfony runtime

### DIFF
--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -5,6 +5,7 @@
 |----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | https://github.com/baldinof/roadrunner-bundle            | [![Version][baldinof_badge_php_version]][baldinof_link_packagist] [![Build Status][baldinof_badge_build_status]][baldinof_link_build_status] [![License][baldinof_badge_license]][baldinof_link_license] |
 | https://github.com/php-runtime/roadrunner-symfony-nyholm | [![Version][phpruntime_badge_php_version]][phpruntime_link_packagist] [![License][phpruntime_badge_license]][phpruntime_link_license]                                                                    |
+| https://github.com/FluffyDiscord/roadrunner-symfony-bundle | [![Version][fluffydiscord_badge_php_version]][fluffydiscord_link_packagist] [![License][fluffydiscord_badge_license]][fluffydiscord_link_license]                                                                    |
 
 [baldinof_badge_packagist_version]:https://img.shields.io/packagist/v/baldinof/roadrunner-bundle.svg?maxAge=180
 [baldinof_badge_php_version]:https://img.shields.io/packagist/php-v/baldinof/roadrunner-bundle.svg?longCache=true
@@ -30,3 +31,11 @@
 [phpruntime_link_build_status]:https://github.com/php-runtime/runtime/actions
 
 [phpruntime_link_license]:https://github.com/php-runtime/roadrunner-symfony-nyholm/blob/master/LICENSE
+
+[fluffydiscord_badge_php_version]:https://img.shields.io/packagist/php-v/FluffyDiscord/roadrunner-symfony-bundle.svg?maxAge=180
+
+[fluffydiscord_badge_license]:https://img.shields.io/packagist/l/FluffyDiscord/roadrunner-symfony-bundle.svg?maxAge=180
+
+[fluffydiscord_link_packagist]:https://packagist.org/packages/FluffyDiscord/roadrunner-symfony-bundle
+
+[fluffydiscord_link_license]:https://github.com/FluffyDiscord/roadrunner-symfony-bundle/blob/master/LICENSE

--- a/integration/symfony.md
+++ b/integration/symfony.md
@@ -1,11 +1,11 @@
 # Integration — Symfony Framework
 
 
-| Repository                                               | Status                                                                                                                                                                                                   |
-|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| https://github.com/baldinof/roadrunner-bundle            | [![Version][baldinof_badge_php_version]][baldinof_link_packagist] [![Build Status][baldinof_badge_build_status]][baldinof_link_build_status] [![License][baldinof_badge_license]][baldinof_link_license] |
-| https://github.com/php-runtime/roadrunner-symfony-nyholm | [![Version][phpruntime_badge_php_version]][phpruntime_link_packagist] [![License][phpruntime_badge_license]][phpruntime_link_license]                                                                    |
-| https://github.com/FluffyDiscord/roadrunner-symfony-bundle | [![Version][fluffydiscord_badge_php_version]][fluffydiscord_link_packagist] [![License][fluffydiscord_badge_license]][fluffydiscord_link_license]                                                                    |
+| Repository                                                 | Status                                                                                                                                                                                                   |
+|------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| https://github.com/baldinof/roadrunner-bundle              | [![Version][baldinof_badge_php_version]][baldinof_link_packagist] [![Build Status][baldinof_badge_build_status]][baldinof_link_build_status] [![License][baldinof_badge_license]][baldinof_link_license] |
+| https://github.com/php-runtime/roadrunner-symfony-nyholm   | [![Version][phpruntime_badge_php_version]][phpruntime_link_packagist] [![License][phpruntime_badge_license]][phpruntime_link_license]                                                                    |
+| https://github.com/FluffyDiscord/roadrunner-symfony-bundle | [![Version][fluffydiscord_badge_php_version]][fluffydiscord_link_packagist] [![License][fluffydiscord_badge_license]][fluffydiscord_link_license]                                                        |
 
 [baldinof_badge_packagist_version]:https://img.shields.io/packagist/v/baldinof/roadrunner-bundle.svg?maxAge=180
 [baldinof_badge_php_version]:https://img.shields.io/packagist/php-v/baldinof/roadrunner-bundle.svg?longCache=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Symfony integration guide to include the new `FluffyDiscord/roadrunner-symfony-bundle` repository along with its version and license status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->