### PR TITLE
chore: Update systemd page

### DIFF
--- a/app-server/systemd.md
+++ b/app-server/systemd.md
@@ -1,4 +1,4 @@
-# Running server as Systemd unit
+# Running server as systemd unit
 
 ## Configuring unit
 

--- a/app-server/systemd.md
+++ b/app-server/systemd.md
@@ -10,7 +10,7 @@ a server:
 ```ini
 [Unit]
 Description=High-performance PHP application server
-Documentation=https://roadrunner.dev/docs
+Documentation=https://docs.roadrunner.dev/
 
 [Service]
 ExecStart=/usr/local/bin/rr serve -c /var/www/.rr.yaml

--- a/app-server/systemd.md
+++ b/app-server/systemd.md
@@ -81,7 +81,7 @@ Example output:
 ● rr.service - High-performance PHP application server
      Loaded: loaded (/lib/systemd/system/rr.service; enabled; vendor preset: enabled)
      Active: active (running) since Tue 2024-03-12 19:20:55 UTC; 35min ago
-     Docs: https://roadrunner.dev/docs
+     Docs: https://docs.roadrunner.dev/
      CGroup: /system.slice/rr.service
              ├─2835793 /usr/local/bin/rr serve -c /var/www/.rr.yaml
              ├─2895807 /usr/local/bin/php worker.php

--- a/app-server/systemd.md
+++ b/app-server/systemd.md
@@ -1,4 +1,6 @@
-# Running server as daemon on Linux
+# Running server as Systemd unit
+
+## Configuring unit
 
 Here you can find an example of systemd unit file that can be used to run RoadRunner as a daemon on
 a server:
@@ -7,16 +9,19 @@ a server:
 
 ```ini
 [Unit]
-Description = High-performance PHP application server
+Description=High-performance PHP application server
+Documentation=https://roadrunner.dev/docs
 
 [Service]
-Type = simple
-ExecStart = /usr/local/bin/rr serve -c /var/www/.rr.yaml
-Restart = always
-RestartSec = 30
+ExecStart=/usr/local/bin/rr serve -c /var/www/.rr.yaml
+
+Type=notify
+
+Restart=always
+RestartSec=30
 
 [Install]
-WantedBy = default.target 
+WantedBy=default.target 
 ```
 
 {% endcode %}
@@ -59,10 +64,53 @@ This will start RoadRunner as a daemon on the server.
 For more information about systemd unit files, the user can refer to the
 following [link](https://wiki.archlinux.org/index.php/systemd#Writing_unit_files).
 
-## SDNotify support
+## Status and logs
 
-RR supports SDNotify protocol. You can use it to notify systemd about the readiness of your application. You don't need
-to configure anything, RR will automatically detect systemd and send the notification. The only one option which might be
+Make sure that the systemd service has started successfully, use the command:
+
+{% code %}
+
+```bash
+systemctl status rr.service
+```
+{% endcode %}
+
+Example output:
+
+```
+● rr.service - High-performance PHP application server
+     Loaded: loaded (/lib/systemd/system/rr.service; enabled; vendor preset: enabled)
+     Active: active (running) since Tue 2024-03-12 19:20:55 UTC; 35min ago
+     Docs: https://roadrunner.dev/docs
+     CGroup: /system.slice/rr.service
+             ├─2835793 /usr/local/bin/rr serve -c /var/www/.rr.yaml
+             ├─2895807 /usr/local/bin/php worker.php
+             ├─2897198 /usr/local/bin/php worker.php
+             ├─2897765 /usr/local/bin/php worker.php
+```
+
+To view logs in real time, use the command:
+
+{% code %}
+
+```bash
+journalctl -f -u rr.service
+```
+
+{% endcode %}
+
+Example output with `info` [level logs](../lab/logger.md#level):
+
+```bash
+Mar 12 20:12:53 server systemd[1]: Starting PHP application server...
+Mar 12 20:12:55 server rr[2936506]: [INFO] RoadRunner server started; version: 2023.3.10, buildtime: 2024-02-01T22:33:17+0000
+Mar 12 20:12:55 server rr[2936506]: [INFO] sdnotify: notified
+Mar 12 20:12:55 server systemd[1]: Started PHP application server.
+```
+
+## `sd_notify` protocol
+
+Roadrunner supports [sd_notify](https://man.archlinux.org/man/sd_notify.3.en) protocol. You can use it to notify systemd about the readiness of your application. Don't forget to add `Type=notify` directive to the `Service` section, Roadrunner will automatically detect systemd and send the notification. The only one option which might be
 configured is watchdog timeout. By default, it's turned off. You can enable it by setting the following option in your
 `.rr.yaml` config:
 


### PR DESCRIPTION
I updated the unit configuration to support the `sd_notify` protocol. Also added log and systemd status examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the guide for running the server on Linux: transitioned from daemon to Systemd unit. Includes configuring the unit file, service settings adjustments, documentation links, and instructions for status and logs checking. Clarified `sd_notify` protocol usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->