### PR TITLE
fix typo in centrifuge.md

### DIFF
--- a/plugins/centrifuge.md
+++ b/plugins/centrifuge.md
@@ -1,7 +1,7 @@
 # Centrifuge
 
 The RoadRunner Centrifuge plugin provides seamless integration with [Centrifugo](https://centrifugal.dev/), a powerful
-websocket server. This plugin allows you to proxy events from Websocket serer to PHP workers running on RoadRunner and
+websocket server. This plugin allows you to proxy events from Websocket server to PHP workers running on RoadRunner and
 send data back to the websocket client, enabling real-time communication between the server and the client.
 
 The plugin provides the following features:


### PR DESCRIPTION
fix `serer` typo to `server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the description of the Centrifuge plugin, changing "Websocket serer" to "Websocket server."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->