### PR TITLE
otel.endpoint port 4318

### DIFF
--- a/kv/overview-kv.md
+++ b/kv/overview-kv.md
@@ -44,7 +44,7 @@ otel:
   insecure: true
   compress: false
   exporter: otlp
-  endpoint: 127.0.0.1:4317
+  endpoint: 127.0.0.1:4318
 ```
 
 {% endcode %}

--- a/lab/otel.md
+++ b/lab/otel.md
@@ -38,7 +38,7 @@ otel:
   insecure: true
   compress: false
   exporter: otlp
-  endpoint: 127.0.0.1:4317
+  endpoint: 127.0.0.1:4318
 ```
 {% endcode %}
 
@@ -56,7 +56,7 @@ otel:
     service_version: "${OTEL_SERVICE_VERSION:-1.0.0}"
   insecure: "${OTEL_EXPORTER_OTLP_INSECURE:-true}"
   exporter: "${OTEL_TRACES_EXPORTER:-otlp}"
-  endpoint: "${OTEL_EXPORTER_OTLP_ENDPOINT:-127.0.0.1:4317}"
+  endpoint: "${OTEL_EXPORTER_OTLP_ENDPOINT:-127.0.0.1:4318}"
 
 ```
 {% endcode %}


### PR DESCRIPTION
Fix for https://github.com/roadrunner-server/docs/issues/14

If I use 4317 port from exmple then rr show this error. 

2024/06/06 10:05:09 traces export: Post "http://collector:4317/v1/traces": net/http: HTTP/1.x transport connection broken: malformed HTTP response "\x00\x00\x06\x04\x00\x00\x00\x00\x00\x00\x05\x00\x00@\x00"

When I use `4318` it's works fine.

Also I see port `4318` in examples below in the text. 

I come to the conclusion that there is a typo in the rr example and port 4318 must be here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the endpoint configuration for the OTLP exporter from `127.0.0.1:4317` to `127.0.0.1:4318` to ensure proper connectivity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->