### PR TITLE
Fix typo: encodin → encoding

### DIFF
--- a/http/gzip.md
+++ b/http/gzip.md
@@ -1,6 +1,6 @@
 # HTTP — Gzip middleware
 
-The gzip middleware is used to support the `accept-encodin: gzip` header and to compress and decompress the contents of the
+The gzip middleware is used to support the `Accept-Encoding: gzip` header and to compress and decompress the contents of the
 outgoing/incoming requests.
 
 ## Documentation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the header in the gzip middleware description from `accept-encodin: gzip` to `Accept-Encoding: gzip`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->