### PR TITLE
fix fileserver cache_duration example

### DIFF
--- a/http/static.md
+++ b/http/static.md
@@ -145,7 +145,7 @@ fileserver:
     - prefix: "/foo/bar"
       root: "../../../tests"
       compress: false
-      cache_duration: 10s
+      cache_duration: 10
       max_age: 10
       bytes_range: true
 ```


### PR DESCRIPTION
`cache_duration: 10s` - invalid value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the `cache_duration` setting for improved caching behavior. 

- **Chores**
	- Updated configuration to streamline performance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->