### PR TITLE
Fix broken protobuf link

### DIFF
--- a/kv/overview-kv.md
+++ b/kv/overview-kv.md
@@ -356,7 +356,7 @@ To make it easy to use the KV proto API in PHP, we provide
 a [GitHub repository](https://github.com/roadrunner-php/roadrunner-api-dto), that contains all the generated PHP DTO
 classes proto files, making it easy to work with these files in your PHP application.
 
-- [API](https://github.com/roadrunner-server/api/blob/master/kv/v1/kv.proto)
+- [API](https://github.com/roadrunner-server/api/blob/master/proto/kv/v1/kv.proto)
 
 ### RPC API
 


### PR DESCRIPTION
- Adjust the Github link to the protobuf API docs for Roadrunner KV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hyperlink for the KV proto API reference to reflect the correct path structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->