### PR TITLE
Added a modern OpenTelemetry compatible tracing system

### DIFF
--- a/kv/overview-kv.md
+++ b/kv/overview-kv.md
@@ -49,8 +49,8 @@ otel:
 
 {% endcode %}
 
-After that, you can see traces in your [Jaeger](https://www.jaegertracing.io/), [Uptrace](https://uptrace.dev/), [Zipkin](https://zipkin.io/) or any 
-other opentelemetry compatible tracing system.
+After that, you can see traces in your [Dash0](https://www.dash0.com/), [Jaeger](https://www.jaegertracing.io/), [Uptrace](https://uptrace.dev/), 
+[Zipkin](https://zipkin.io/) or any other opentelemetry compatible tracing system.
 
 
 ## Configuration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the RoadRunner KV plugin documentation to replace "Jaeger" with "Dash0" in the tracing systems section.
	- Maintained the overall structure and core information regarding configuration, usage, and API of the KV plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->