### PR TITLE
Update temporal documentation links

### DIFF
--- a/workflow/temporal.md
+++ b/workflow/temporal.md
@@ -74,4 +74,4 @@ class SubscriptionWorkflow implements SubscriptionWorkflowInterface
 }
 ```
 
-> Read more at [official website](https://docs.temporal.io/application-development?lang=php).
+> Read more at [official website](https://docs.temporal.io/develop/php/).

--- a/workflow/worker.md
+++ b/workflow/worker.md
@@ -37,7 +37,7 @@ $worker->registerActivityImplementations(new MyActivity());
 $factory->run();
 ```
 
-Read more about temporal configuration and usage [at official website](https://docs.temporal.io/develop/php/). 
+Read more about temporal configuration and usage [at official website](https://docs.temporal.io/develop/php/core-application#run-a-dev-worker). 
 
 ## Multi-worker Environment
 To serve both HTTP and Temporal from the same worker use `getMode()` option of `Environment`:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL in the Temporal.IO documentation to direct users to the PHP development section.
	- Revised the link for configuring a Temporal worker in PHP to a more specific section on running a development worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->