### PR TITLE
Fix quick start .rr.yaml

### DIFF
--- a/intro/quick-start.md
+++ b/intro/quick-start.md
@@ -17,6 +17,8 @@ Next, you need to create a simple configuration file for RR. Open a text editor 
 {% code title=".rr.yaml" %}
 
 ```yaml
+version: "3"
+
 server:
   command: "php psr-worker.php"
 


### PR DESCRIPTION
Got error when trying config file in quick start.

```
> rr serve 
handle_serve_command: rr configuration file should contain a version e.g: version: 3
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded configuration management by introducing a version specification to enhance compatibility as the system evolves. This adjustment maintains all existing settings and commands while laying the groundwork for smoother future updates. Users will benefit from enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->