### PR TITLE
Update plugins/grpc.md

### DIFF
--- a/plugins/grpc.md
+++ b/plugins/grpc.md
@@ -285,6 +285,7 @@ use Spiral\RoadRunner\GRPC\Server;
 use Spiral\RoadRunner\Worker;
 
 require __DIR__ . '/vendor/autoload.php';
+require 'Greeter.php';
 
 $server = new Server(new Invoker(), [
     'debug' => false, // optional (default: false)

--- a/plugins/grpc.md
+++ b/plugins/grpc.md
@@ -375,6 +375,43 @@ After configuring the server, you can start it using the following command:
 This will start the gRPC server and make the `Greeter` service available for remote clients to call. You can use any gRPC
 client library in any language that supports gRPC to call the `SayHello` method.
 
+To quickly verify your code's correctness, you can install [grpc-client-cli](https://github.com/vadimi/grpc-client-cli) which
+provides an interactive CLI tool for talking to gRPC services.
+
+To access the `Greeter` service with `grpc-client-cli` run the following in a terminal:
+
+`grpc-client-cli --proto proto/helloworld.proto 127.0.0.1:9001`
+
+It will provide some interactive prompts asking you what service and method you want to call
+
+```shell
+? Choose a service:  [Use arrows to move, type to filter]
+→ helloworld.Greeter
+
+? Choose a method:  [Use arrows to move, type to filter]
+  [..]
+→ SayHello
+```
+
+You will then be prompted to manually form the JSON payload it expects and upon pressing enter, your `Greeter` service
+should respond in an amicable manner:
+
+```
+Message json (type ? to see defaults): {"name":"Roadrunner"}
+{
+  "message": "Hello Roadrunner!"
+}
+```
+
+On the PHP side, you should see that the successful request has been logged:
+
+```
+2025-03-28T10:04:06+0000        DEBUG   server          req-resp mode   {"pid": 81551}
+2025-03-28T10:04:06+0000        DEBUG   grpc            method was called successfully  {"method": "/helloworld.Greeter/SayHello", "start": "2025-03-28T10:04:06+0000", "elapsed": 0}
+```
+
+Congratulations on being able to communicate over gRPC to PHP using Roadrunner!
+
 ## Metrics
 
 RoadRunner has a [metrics plugin](../lab/metrics.md) that provides metrics for the gRPC server, which can be used with

--- a/plugins/grpc.md
+++ b/plugins/grpc.md
@@ -194,23 +194,23 @@ Here's an example of a `buf.gen.yaml` file:
 version: v2
 plugins:
   - remote: buf.build/protocolbuffers/php:v26.1
-    out: gen/php
+    out: generated/php
   - remote: buf.build/community/roadrunner-server-php-grpc:v4.8.0
-    out: gen/php
+    out: generated/php
   - remote: buf.build/protocolbuffers/go:v1.32.0
-    out: gen/go
+    out: generated/go
     opt: paths=source_relative
   - remote: buf.build/grpc/go:v1.3.0
-    out: gen/go
+    out: generated/go
     opt:
       - paths=source_relative
       - require_unimplemented_servers=false
   - remote: buf.build/grpc/python:v1.63.0
-    out: gen/python
+    out: generated/python
   - remote: buf.build/protocolbuffers/python
-    out: gen/python
+    out: generated/python
   - remote: buf.build/protocolbuffers/pyi
-    out: gen/python
+    out: generated/python
 ```
 
 {% endcode %}

--- a/plugins/grpc.md
+++ b/plugins/grpc.md
@@ -25,6 +25,7 @@ directory:
 ```proto
 syntax = "proto3";
 
+option go_package = "proto/greeter";
 option php_namespace = "GRPC\\Greeter";
 option php_metadata_namespace = "GRPC\\GPBMetadata";
 

--- a/plugins/grpc.md
+++ b/plugins/grpc.md
@@ -246,6 +246,8 @@ Here's an example:
 {% code title="Greeter.php" %}
 
 ```php
+<?php
+
 use Spiral\RoadRunner\GRPC;
 use GRPC\Greeter\GreeterInterface;
 use GRPC\Greeter\HelloRequest;
@@ -275,6 +277,8 @@ Here's an example of how to do this:
 {% code title="grpc-worker.php" %}
 
 ```php
+<?php
+
 use GRPC\Greeter\GreeterInterface;
 use Spiral\RoadRunner\GRPC\Invoker;
 use Spiral\RoadRunner\GRPC\Server;


### PR DESCRIPTION
* Imports `Spiral\RoadRunner\GRPC\Invoker` as required when creating a `Spiral\RoadRunner\GRPC\Server`.
* Migrates to using a "Hello World" gRPC service so when copying the example it'll work without external dependencies. (inspired by gRPC's [helloworld.proto](https://github.com/grpc/grpc-go/blob/master/examples/helloworld/helloworld/helloworld.proto))

I did wonder about mentioning the use of [grpc-client-cli](https://github.com/vadimi/grpc-client-cli) as a way to debug/test talking directly with the instantiated gRPC server, but maybe that's a thought for you to verify as it's an external project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Upgraded the gRPC service to deliver greeting functionality with a dedicated endpoint that accepts a name and returns a greeting message.

- **Documentation**
	- Updated service references and command examples to align with the new gRPC service structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->