### PR TITLE
Customization > Build: Remove empty proxy middleware

### DIFF
--- a/customization/build.md
+++ b/customization/build.md
@@ -65,7 +65,6 @@ gzip = { ref = "v5.0.2", owner = "roadrunner-server", repository = "gzip" }
 prometheus = { ref = "v5.0.1", owner = "roadrunner-server", repository = "prometheus" }
 headers = { ref = "v5.0.2", owner = "roadrunner-server", repository = "headers" }
 static = { ref = "v5.0.1", owner = "roadrunner-server", repository = "static" }
-proxy = { ref = "v5.0.2", owner = "roadrunner-server", repository = "proxy_ip_parser" }
 send = { ref = "v5.0.1", owner = "roadrunner-server", repository = "send" }
 
 # OpenTelemetry


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration example by removing the `proxy` plugin entry from the HTTP + MIDDLEWARE section in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->