### PR TITLE
Specify port number for pprof server in debug mode

### DIFF
--- a/app-server/cli.md
+++ b/app-server/cli.md
@@ -85,7 +85,7 @@ a `.pid` file:
 ## Debug mode
 
 RoadRunner also supports running the Golang pprof server in debug mode using the `-d` option. This option enables the
-debug mode, which starts the pprof server and listens for incoming requests on the port 6061.
+debug mode, which starts the pprof server and listens for incoming requests on port 6061.
 
 {% code %}
 

--- a/app-server/cli.md
+++ b/app-server/cli.md
@@ -85,7 +85,7 @@ a `.pid` file:
 ## Debug mode
 
 RoadRunner also supports running the Golang pprof server in debug mode using the `-d` option. This option enables the
-debug mode, which starts the pprof server and listens for incoming requests on the configured port.
+debug mode, which starts the pprof server and listens for incoming requests on the port 6061.
 
 {% code %}
 


### PR DESCRIPTION
Default port of pprof is 6060, but in https://github.com/roadrunner-server/roadrunner/blob/master/internal/cli/root.go#L105 it started on  6061 that is not clearly undestand
Clarify the port number for the pprof server in debug mode.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation for debug mode (-d) to explicitly state that the profiler listens for incoming requests on port 6061 (replacing the previous, non-specific "configured port" wording).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->